### PR TITLE
Add missing translation calls and improve locale handling in authentication views

### DIFF
--- a/app/Http/Middleware/SetLocale.php
+++ b/app/Http/Middleware/SetLocale.php
@@ -38,12 +38,12 @@ class SetLocale
     public static function getTranslations()
     {
         // Less cache hits if its english, this is default language
-        if (app()->getLocale() == 'en') {
+        if (setting('default_language') == 'en') {
             return [];
         }
 
         $resolver = function () {
-            $translationFile = resource_path('lang/' . app()->getLocale() . '.json');
+            $translationFile = resource_path('lang/' . setting('default_language') . '.json');
 
             if (!is_readable($translationFile)) {
                 return [];
@@ -56,6 +56,6 @@ class SetLocale
             return $resolver();
         }
 
-        return \Cache::remember('translations-' . app()->getLocale(), now()->addDay(), $resolver);
+        return \Cache::remember('translations-' . setting('default_language'), now()->addDay(), $resolver);
     }
 }

--- a/resources/js/Pages/Auth/ConfirmTwoFactorAuthentication.vue
+++ b/resources/js/Pages/Auth/ConfirmTwoFactorAuthentication.vue
@@ -6,7 +6,7 @@
                 <div class="flex flex-col items-center space-y-5">
                     <img class="h-14" v-if="$page.props.settings.logo" :src="$page.props.settings.logo" />
                     <h1 class="font-semibold text-center text-title">
-                        Confirm access to {{ $page.props.settings.name }}
+                        {{ __('Confirm access to') }} {{ $page.props.settings.name }}
                     </h1>
                 </div>
 
@@ -21,13 +21,13 @@
                     <div v-if="$page.props.settings.has_terms">
                         <inertia-link :href="route('page.show', 'terms-of-service')"
                                       class="text-small text-medium-emphasis hover:text-high-emphasis border-b border-dotted">
-                            Terms Of Service
+                            {{ __('Terms Of Service') }}
                         </inertia-link>
                     </div>
                     <div v-if="$page.props.settings.has_privacy">
                         <inertia-link :href="route('page.show', 'privacy-policy')"
                                       class="text-small text-medium-emphasis hover:text-high-emphasis border-b border-dotted">
-                            Privacy Policy
+                            {{ __('Privacy Policy') }}
                         </inertia-link>
                     </div>
                 </div>

--- a/resources/js/Pages/Auth/Login.vue
+++ b/resources/js/Pages/Auth/Login.vue
@@ -6,7 +6,7 @@
                 <div class="flex flex-col items-center space-y-5">
                     <img class="h-14" v-if="$page.props.settings.logo" :src="$page.props.settings.logo" />
                     <h1 class="font-semibold text-center text-title">
-                        Login to {{ $page.props.settings.name }}
+                        {{ __('Login to') }} {{ $page.props.settings.name }}
                     </h1>
                 </div>
 
@@ -26,7 +26,7 @@
 
                 <div class="space-y-3">
                     <Button as="inertia-link" :href="route('register')" variant="secondary" :disabled="sending"
-                            v-if="$page.props.settings.allow_registration" block>Register
+                            v-if="$page.props.settings.allow_registration" block>{{ __('Register') }}
                     </Button>
                 </div>
 
@@ -37,13 +37,13 @@
                     <div v-if="$page.props.settings.has_terms">
                         <inertia-link :href="route('page.show', 'terms-of-service')"
                                       class="text-small text-medium-emphasis hover:text-high-emphasis border-b border-dotted">
-                            Terms Of Service
+                            {{ __('Terms Of Service') }}
                         </inertia-link>
                     </div>
                     <div v-if="$page.props.settings.has_privacy">
                         <inertia-link :href="route('page.show', 'privacy-policy')"
                                       class="text-small text-medium-emphasis hover:text-high-emphasis border-b border-dotted">
-                            Privacy Policy
+                            {{ __('Privacy Policy') }}
                         </inertia-link>
                     </div>
                 </div>

--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -39,13 +39,13 @@
                     <div v-if="$page.props.settings.has_terms">
                         <inertia-link :href="route('page.show', 'terms-of-service')"
                                       class="text-small text-medium-emphasis hover:text-high-emphasis border-b border-dotted">
-                            Terms Of Service
+                            {{ __('Terms Of Service') }}
                         </inertia-link>
                     </div>
                     <div v-if="$page.props.settings.has_privacy">
                         <inertia-link :href="route('page.show', 'privacy-policy')"
                                       class="text-small text-medium-emphasis hover:text-high-emphasis border-b border-dotted">
-                            Privacy Policy
+                            {{ __('Privacy Policy') }}
                         </inertia-link>
                     </div>
                 </div>

--- a/resources/lang/da.json
+++ b/resources/lang/da.json
@@ -104,6 +104,9 @@
     "Auto": "Auto",
     "site|sites": "side|sider",
 
+    "Login to": "Log ind til",
+    "Register": "Opret bruger",
+
     "Support requests": "Support anmodninger",
     "Open support requests": "Åbne support anmodninger",
     "Closed support requests": "Lukkede support anmodninger",

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -104,6 +104,9 @@
     "Auto": "Automatico",
     "site|sites": "sitio|sitios",
 
+    "Login to": "Iniciar sesion a",
+    "Register": "Crear cuenta",
+
     "Support requests": "Solicitudes de soporte",
     "Open support requests": "Solicitudes de sporte abiertas",
     "Closed support requests": "Solicitudes de soporte cerradas",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -93,6 +93,9 @@
     "Dark": "Sombre",
     "Auto": "Automatique",
 
+    "Login to": "Connexion à",
+    "Register": "Créer un compte",
+
     "Support requests": "Requêtes",
     "Open support requests": "Requêtes en cours",
     "Closed support requests": "Requêtes fermées",

--- a/resources/lang/nb-no.json
+++ b/resources/lang/nb-no.json
@@ -93,6 +93,9 @@
     "Dark": "Mørk",
     "Auto": "Auto",
 
+    "Login to": "Logg inn til",
+    "Register": "Opprett konto",
+
     "Support requests": "Supportforespørsler",
     "Open support requests": "Åpne supportforespørsler",
     "Closed support requests": "Lukkede supportforespørsler",

--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -107,6 +107,8 @@
     "Light": "Licht",
     "Dark": "Donker",
     "Auto": "Automatisch",
+    "Login to": "Inloggen bij",
+    "Register": "Een account aanmaken",
     "site|sites": "website|websites",
     "WordPress installed": "WordPress geïnstalleerd",
     "On server": "Op server",

--- a/resources/lang/pt.json
+++ b/resources/lang/pt.json
@@ -104,6 +104,9 @@
     "Auto": "Automático",
     "site|sites": "website|websites",
 
+    "Login to": "Entrar em",
+    "Register": "Registrar",
+
     "Support requests": "Pedidos de suporte",
     "Open support requests": "Solicitações de suporte abertas",
     "Closed support requests": "Pedidos de suporte fechados",

--- a/resources/lang/zh.json
+++ b/resources/lang/zh.json
@@ -104,6 +104,9 @@
     "Auto": "自动",
     "site|sites": "站点|站群",
 
+    "Login to": "登入",
+    "Register": "注册",
+
     "Support requests": "请求支持",
     "Open support requests": "开启支持",
     "Closed support requests": "关闭支持",


### PR DESCRIPTION
Hi everyone,

This PR improves translation support across all authentication views by wrapping previously hardcoded strings in the __() helper.
I also updated the SetLocale middleware to use setting('default_language') for a more consistent locale fallback, and added a few missing translations to the locale files (e.g. fr.json).

Let me know if you'd prefer this split into multiple commits or if any part needs revision.

Thanks in advance for your feedback! 🙌

### Summary of changes:

- Replaced hardcoded strings in all authentication-related views with `__()` helper calls (e.g., `__('Login to')`, `__('Register')`) to support full localization.
- Updated the `SetLocale` middleware to use `setting('default_language')` instead of `app()->getLocale()` as the fallback language source.
- Added missing translations across locale files (e.g., `fr.json`), such as:
  ```json
  {
    "Login to": "Connexion à",
    "Register": "Créer un compte"
  }
