### PR TITLE
Add phpmyadmin_link field to server and database management interfaces

### DIFF
--- a/app/Filament/Resources/ServerResource.php
+++ b/app/Filament/Resources/ServerResource.php
@@ -51,6 +51,9 @@ class ServerResource extends Resource
                     ->integer()
                     ->required()
                     ->columnSpan(2),
+                Forms\Components\TextInput::make('phpmyadmin_link')
+                    ->label(__('PhpMyAdmin link'))
+                    ->columnSpan(2),
             ]);
     }
 

--- a/app/Http/Controllers/ServerController.php
+++ b/app/Http/Controllers/ServerController.php
@@ -47,6 +47,7 @@ class ServerController extends Controller
             'provider_region_id' => ['required'],
             'provider_plan_id' => ['required'],
             'database_type' => ['required'],
+            'phpmyadmin_link' => ['nullable'],
         ]);
 
         $data['user_id'] = Auth::id();

--- a/app/Http/Controllers/SiteDatabaseController.php
+++ b/app/Http/Controllers/SiteDatabaseController.php
@@ -13,10 +13,12 @@ class SiteDatabaseController extends Controller
     public function index($id)
     {
         $site = auth()->user()->sites()->findOrFail($id);
+        $phpmyadminLink = $site->server->phpmyadmin_link;
 
         return inertia('Sites/Databases', [
             'site' => $site,
             'databases' => SiteDatabaseResource::collection($site->databases()->latest()->paginate()),
+            'phpmyadminlink' => $phpmyadminLink,
         ]);
     }
 

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -27,7 +27,8 @@ class Server extends Model
         'ssh_port',
         'maximum_sites',
         'available_php_versions',
-        'database_type'
+        'database_type',
+        'phpmyadmin_link'
     ];
 
     protected $casts = [

--- a/database/migrations/2025_04_30_092938_add_phpmyadmin_link_to_servers_table.php
+++ b/database/migrations/2025_04_30_092938_add_phpmyadmin_link_to_servers_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            $table->string('phpmyadmin_link')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('servers', function (Blueprint $table) {
+            $table->dropColumn('phpmyadmin_link');
+        });
+    }
+};

--- a/resources/js/Pages/Servers/Settings.vue
+++ b/resources/js/Pages/Servers/Settings.vue
@@ -24,6 +24,9 @@
                                         <FormInput :label="__('Name')" :errors="$page.props.errors.name"
                                                    v-model="form.name" />
 
+                                        <FormInput :label="__('PhpMyAdmin link')" :errors="$page.props.errors.phpmyadmin_link"
+                                                   v-model="form.phpmyadmin_link" />
+
                                         <FormActions>
                                             <Button>{{ __('Save') }}</Button>
                                         </FormActions>
@@ -134,7 +137,8 @@ export default {
     data() {
         return {
             form: {
-                name: this.server.name
+                name: this.server.name,
+                phpmyadmin_link: this.server.phpmyadmin_link,
             },
 
             breadcrumbs: [

--- a/resources/js/Pages/Sites/Databases.vue
+++ b/resources/js/Pages/Sites/Databases.vue
@@ -59,12 +59,18 @@
                                                             :variant="database.status === 'busy' ? 'gray' : 'success'" />
                                                     </TableData>
                                                     <TableData>{{ database.name }}</TableData>
-                                                    <TableData>
-                                                        <Button :disabled="database.status === 'busy'" variant="danger"
-                                                                size="sm"
-                                                                @click="confirmDelete(database)">
-                                                            {{ __('Delete') }}
-                                                        </Button>
+                                                    <TableData class="flex justify-end">
+                                                        <div class="flex gap-2">
+                                                            <Button v-if="phpmyadminlink" as="a" :href="phpmyadminlink"
+                                                                    target="_blank" variant="primary" size="sm">
+                                                                PhpMyAdmin
+                                                            </Button>
+                                                            <Button :disabled="database.status === 'busy'" variant="danger"
+                                                                    size="sm"
+                                                                    @click="confirmDelete(database)">
+                                                                {{ __('Delete') }}
+                                                            </Button>
+                                                        </div>
                                                     </TableData>
                                                 </TableRow>
                                             </TableBody>
@@ -212,6 +218,7 @@ export default {
     props: {
         site: Object,
         databases: Object,
+        phpmyadminlink: String,
     },
 
     methods: {


### PR DESCRIPTION
Hi,

This PR implements the ability to configure a custom PhpMyAdmin link per server, as requested in roadmap item #84.

The new phpmyadmin_link field has been added across the backend (model, controller, validation) and frontend (server settings form + display in the database management UI).

This provides users with a convenient way to access their PhpMyAdmin instance based on server-specific configuration.

Looking forward to your feedback! 🙌
🔗 [Roadmap item link](https://roadmap.ploi.io/projects/4-ploi-core-requests/items/84-ploi-core-phpmyadmin)

### Summary of changes:

- Introduced the `phpmyadmin_link` field to improve PhpMyAdmin integration across the UI:
  - `ServerResource.php`: added field to the server edit form.
  - `ServerController.php`: added validation for `phpmyadmin_link`.
  - `Server.php`: included the field in `$fillable`.
  - `Settings.vue`: integrated the field in the server settings UI.
  - `SiteDatabaseController.php` & `Databases.vue`: added PhpMyAdmin link display in the database interface.

🎯 Goal: Allow per-server configuration of PhpMyAdmin URL.

🔗 Related roadmap ticket:  
https://roadmap.ploi.io/projects/4-ploi-core-requests/items/84-ploi-core-phpmyadmin

Let me know if anything needs adjusting!