### PR TITLE
Use the proper route for in new ticket received mail.

### DIFF
--- a/resources/views/emails/support/new-ticket-received.blade.php
+++ b/resources/views/emails/support/new-ticket-received.blade.php
@@ -3,7 +3,7 @@
 
 {{ __('A new support ticket has came in. Press the button below to view the ticket.') }}
 
-@component('mail::button', ['url' => route('admin.support.show', $supportTicket->id)])
+@component('mail::button', ['url' => route('filament.admin.resources.support-tickets.view', $supportTicket->id)])
     {{ __('View ticket') }}
 @endcomponent
 @endcomponent


### PR DESCRIPTION
Currently when you create a support ticket the notifications errors saying the route `admin.support.show` does not exist.

You can easily verify this by running `php artisan route:list --name=support` which shows the defined routes:


```bash
  GET|HEAD   admin/support-tickets filament.admin.resources.support-tickets.index › App\Filament\Resources\SupportTicketResource\Pages\ListSupportTicke…
  GET|HEAD   admin/support-tickets/{record} filament.admin.resources.support-tickets.view › App\Filament\Resources\SupportTicketResource\Pages\ViewSupp…
  GET|HEAD   support ........................................................................................... support.index › SupportController@index
  POST       support ........................................................................................... support.store › SupportController@store
  GET|HEAD   support/closed ....................................................................... support.index.closed › SupportController@indexClosed
  GET|HEAD   support/create .................................................................................. support.create › SupportController@create
  GET|HEAD   support/{support} ................................................................................... support.show › SupportController@show
  POST       support/{support}/close ........................................................................... support.close › SupportController@close
  POST       support/{support}/reply ........................................................................... support.reply › SupportController@reply
```

This PR uses the proper route: `filament.admin.resources.support-tickets.view`.