### PR TITLE
Fix closing and reopening of support tickets.

### DIFF
--- a/app/Filament/Resources/SupportTicketResource/Pages/ViewSupportTicket.php
+++ b/app/Filament/Resources/SupportTicketResource/Pages/ViewSupportTicket.php
@@ -45,7 +45,7 @@ class ViewSupportTicket extends Page
                         ->success()
                         ->send();
 
-                    $livewire->redirect(SupportTicketResource::getUrl('view', ['record' => $livewire->getRecord()]));
+                    $livewire->redirect(SupportTicketResource::getUrl('view', ['record' => $livewire->record]));
                 })
                 ->visible(fn (self $livewire) => $livewire->record->status !== SupportTicket::STATUS_CLOSED)
                 ->color('danger'),
@@ -60,7 +60,7 @@ class ViewSupportTicket extends Page
                         ->success()
                         ->send();
 
-                    $livewire->redirect(SupportTicketResource::getUrl('view', ['record' => $livewire->getRecord()]));
+                    $livewire->redirect(SupportTicketResource::getUrl('view', ['record' => $livewire->record]));
                 })
                 ->visible(fn (self $livewire) => $livewire->record->status === SupportTicket::STATUS_CLOSED)
                 ->color('primary'),


### PR DESCRIPTION
Currently the actions are trying to use the `getRecord()` method which doesn't exist. Instead they can directly access the record which is also done a few lines above it.